### PR TITLE
Upgrade to Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
 
     "require": {
         "php": ">=7.2",
-        "illuminate/support": "~6.0",
-        "illuminate/database": "~6.0",
+        "illuminate/support": "~6.0|~7.0",
+        "illuminate/database": "~6.0|~7.0",
         "ixudra/core": "~6.0",
         "laravelcollective/html": "~6.0",
         "laracasts/presenter": "0.2.*"


### PR DESCRIPTION
- Allow illuminate `~7.0` dependencies
- **NOTE**: depends on `ixudra/core` this package should have a new release supporting Laravel 7 first. The package version should be updated in this package as well in order to work.

Fixes #1 